### PR TITLE
fix goimports with vendored code

### DIFF
--- a/gotools_format.py
+++ b/gotools_format.py
@@ -27,7 +27,7 @@ class GotoolsFormat(sublime_plugin.TextCommand):
       args = ["-e", "-s"]
     elif golangconfig.setting_value("format_backend")[0] in ["goimports", "both"] :
       command = "goimports"
-      args = ["-e"]
+      args = ["-e", "-srcdir=%s" % os.path.dirname(self.view.file_name())]
 
     stdout, stderr, rc = ToolRunner.run(self.view, command, args, stdin=Buffers.buffer_text(self.view))
 


### PR DESCRIPTION
Requires a recent version of goimports: https://github.com/golang/tools/commit/bf084ef7580ee99a5efa3086138c942aca4aefd4
