### PR TITLE
Support gocode client mode

### DIFF
--- a/golang.sublime-settings
+++ b/golang.sublime-settings
@@ -18,6 +18,8 @@
   "autocomplete": true,
 
   // Enable GoTools debugging output to the Sublime console.
-  "debug_enabled": false
+  "debug_enabled": false,
 
+  // Enable gocode client mode, github.com/mdempsky/gocode needed
+  "gocode_client_mode": false
 }

--- a/gotools_suggestions.py
+++ b/gotools_suggestions.py
@@ -21,8 +21,8 @@ class GotoolsSuggestions(sublime_plugin.EventListener):
     if not GoBuffers.is_go_source(view): return
     if not golangconfig.setting_value("autocomplete")[0]: return
 
-    gocodeFlags = ["-f=json", "-sock=none"] if golangconfig.setting_value("gocode_client_mode")[0] else ["-f=json"]
-    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", gocodeFlags + ["autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
+    gocodeFlag = ["-f=json", "-sock=none"] if golangconfig.setting_value("gocode_client_mode")[0] else ["-f=json"]
+    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", gocodeFlag + ["autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
 
     suggestionsJson = json.loads(suggestionsJsonStr)
 

--- a/gotools_suggestions.py
+++ b/gotools_suggestions.py
@@ -21,7 +21,8 @@ class GotoolsSuggestions(sublime_plugin.EventListener):
     if not GoBuffers.is_go_source(view): return
     if not golangconfig.setting_value("autocomplete")[0]: return
 
-    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", ["-f=json", "autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
+    gocodeFlags = "-f=json -sock=none" if golangconfig.setting_value("gocode_client_mode")[0] else "-f=json"
+    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", [gocodeFlags, "autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
 
     suggestionsJson = json.loads(suggestionsJsonStr)
 

--- a/gotools_suggestions.py
+++ b/gotools_suggestions.py
@@ -22,7 +22,7 @@ class GotoolsSuggestions(sublime_plugin.EventListener):
     if not golangconfig.setting_value("autocomplete")[0]: return
 
     gocodeFlags = ["-f=json", "-sock=none"] if golangconfig.setting_value("gocode_client_mode")[0] else ["-f=json"]
-    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", [gocodeFlags, "autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
+    suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", gocodeFlags + ["autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
 
     suggestionsJson = json.loads(suggestionsJsonStr)
 

--- a/gotools_suggestions.py
+++ b/gotools_suggestions.py
@@ -21,7 +21,7 @@ class GotoolsSuggestions(sublime_plugin.EventListener):
     if not GoBuffers.is_go_source(view): return
     if not golangconfig.setting_value("autocomplete")[0]: return
 
-    gocodeFlags = "-f=json -sock=none" if golangconfig.setting_value("gocode_client_mode")[0] else "-f=json"
+    gocodeFlags = ["-f=json", "-sock=none"] if golangconfig.setting_value("gocode_client_mode")[0] else ["-f=json"]
     suggestionsJsonStr, stderr, rc = ToolRunner.run(view, "gocode", [gocodeFlags, "autocomplete", view.file_name(), str(locations[0])], stdin=Buffers.buffer_text(view))
 
     suggestionsJson = json.loads(suggestionsJsonStr)


### PR DESCRIPTION
Add a `gocode_client_mode` setting to enable `mdempsky/gocode` 's client mode, performance improved.

I'm not an expert of Sublime Text plugin development, so if there's anything I missed, please just figure it out, thanks in advance.
