### PR TITLE
Fix path handling in goimports and parsing Windows paths

### DIFF
--- a/gotools_format.py
+++ b/gotools_format.py
@@ -27,7 +27,7 @@ class GotoolsFormat(sublime_plugin.TextCommand):
       args = ["-e", "-s"]
     elif golangconfig.setting_value("format_backend")[0] in ["goimports", "both"] :
       command = "goimports"
-      args = ["-e", "-srcdir=%s" % os.path.dirname(self.view.file_name())]
+      args = ["-e"]
 
     stdout, stderr, rc = ToolRunner.run(self.view, command, args, stdin=Buffers.buffer_text(self.view))
 
@@ -96,7 +96,7 @@ class GotoolsFormat(sublime_plugin.TextCommand):
 
     marks = []
     for error in stderr.splitlines():
-      match = re.match("(.*):(\d+):(\d+):", error)
+      match = re.match("((?:[a-zA-Z]:)?.*):(\d+):(\d+):", error)
       if not match or not match.group(2):
         Logger.log("skipping unrecognizable error:\n" + error + "\nmatch:" + str(match))
         continue


### PR DESCRIPTION
This omits srcdir for goimports to fix double prepend of directory:

<img width="810" alt="screen shot 2017-11-12 at 12 36 38" src="https://user-images.githubusercontent.com/192964/32698051-8a82993e-c7a6-11e7-8684-01cc31aff935.png">

Also now parses "C:\x\y\z.go:12:12" correctly.